### PR TITLE
feat(notes): client-side keyword search in NotesPanel (#6)

### DIFF
--- a/frontend/src/components/Notes/NotesPanel.css
+++ b/frontend/src/components/Notes/NotesPanel.css
@@ -88,3 +88,28 @@
   transition: background 0.15s;
 }
 .note-save-btn:hover { background: var(--color-primary-hover); }
+
+/* Search input — sits between the list header and the note items
+   so it scrolls with the panel rather than the editor. */
+.note-search-input {
+  margin: 6px 8px 8px 8px;
+  padding: 6px 8px;
+  font-size: 13px;
+  border: 1px solid var(--color-border, #ddd);
+  border-radius: 4px;
+  background: var(--color-bg-input, #fff);
+  color: inherit;
+  outline: none;
+  transition: border-color 0.15s;
+}
+.note-search-input:focus {
+  border-color: var(--color-primary);
+}
+
+/* "No matches" placeholder — dimmed, italic, not selectable as a note. */
+.note-item-empty {
+  padding: 8px 12px;
+  color: var(--color-text-dim, #888);
+  font-style: italic;
+  font-size: 12px;
+}

--- a/frontend/src/components/Notes/NotesPanel.css
+++ b/frontend/src/components/Notes/NotesPanel.css
@@ -97,7 +97,7 @@
   font-size: 13px;
   border: 1px solid var(--color-border, #ddd);
   border-radius: 4px;
-  background: var(--color-bg-input, #fff);
+  background: var(--color-surface);
   color: inherit;
   outline: none;
   transition: border-color 0.15s;
@@ -109,7 +109,7 @@
 /* "No matches" placeholder — dimmed, italic, not selectable as a note. */
 .note-item-empty {
   padding: 8px 12px;
-  color: var(--color-text-dim, #888);
+  color: var(--color-text-muted);
   font-style: italic;
   font-size: 12px;
 }

--- a/frontend/src/components/Notes/NotesPanel.css
+++ b/frontend/src/components/Notes/NotesPanel.css
@@ -89,7 +89,7 @@
 }
 .note-save-btn:hover { background: var(--color-primary-hover); }
 
-/* Search input — sits between the list header and the note items
+/* Search input, sits between the list header and the note items
    so it scrolls with the panel rather than the editor. */
 .note-search-input {
   margin: 6px 8px 8px 8px;
@@ -106,7 +106,7 @@
   border-color: var(--color-primary);
 }
 
-/* "No matches" placeholder — dimmed, italic, not selectable as a note. */
+/* "No matches" placeholder, dimmed, italic, not selectable as a note. */
 .note-item-empty {
   padding: 8px 12px;
   color: var(--color-text-muted);

--- a/frontend/src/components/Notes/NotesPanel.tsx
+++ b/frontend/src/components/Notes/NotesPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useSpaceStore } from '@/store/spaceStore';
 import './NotesPanel.css';
 
@@ -18,17 +18,27 @@ export default function NotesPanel() {
   const [content, setContent] = useState('');
   const [search, setSearch] = useState('');
 
+  // The trimmed query is the actual filter input; reuse it for the
+  // empty-state message so users see what the filter is matching on
+  // instead of the raw value (e.g. `"   foo  "` → `"foo"`).
+  const trimmedSearch = search.trim();
+
   // Client-side filter — see #6. Empty / whitespace-only input is
   // treated as "no filter" so clearing the box restores the full list.
-  const visibleNotes = (() => {
-    const q = search.trim().toLowerCase();
+  // Memoised so unrelated re-renders (e.g. typing in the editor textarea)
+  // don't pay the filter cost.
+  // `title`/`content` come from the API as `Optional[str]` on the
+  // backend — coerce nulls to empty strings before lower-casing so a
+  // missing field doesn't throw.
+  const visibleNotes = useMemo(() => {
+    const q = trimmedSearch.toLowerCase();
     if (q === '') return notes;
     return notes.filter(
       n =>
-        n.title.toLowerCase().includes(q) ||
-        n.content.toLowerCase().includes(q),
+        (n.title ?? '').toLowerCase().includes(q) ||
+        (n.content ?? '').toLowerCase().includes(q),
     );
-  })();
+  }, [notes, trimmedSearch]);
 
   const fetchNotes = async () => {
     if (!activeSpaceId) return;
@@ -91,8 +101,8 @@ export default function NotesPanel() {
             {n.title || 'Untitled'}
           </div>
         ))}
-        {visibleNotes.length === 0 && search.trim() !== '' && (
-          <div className="note-item-empty">No notes match “{search}”.</div>
+        {visibleNotes.length === 0 && trimmedSearch !== '' && (
+          <div className="note-item-empty">No notes match "{trimmedSearch}".</div>
         )}
       </div>
 

--- a/frontend/src/components/Notes/NotesPanel.tsx
+++ b/frontend/src/components/Notes/NotesPanel.tsx
@@ -16,6 +16,19 @@ export default function NotesPanel() {
   const [activeNote, setActiveNote] = useState<Note | null>(null);
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
+  const [search, setSearch] = useState('');
+
+  // Client-side filter — see #6. Empty / whitespace-only input is
+  // treated as "no filter" so clearing the box restores the full list.
+  const visibleNotes = (() => {
+    const q = search.trim().toLowerCase();
+    if (q === '') return notes;
+    return notes.filter(
+      n =>
+        n.title.toLowerCase().includes(q) ||
+        n.content.toLowerCase().includes(q),
+    );
+  })();
 
   const fetchNotes = async () => {
     if (!activeSpaceId) return;
@@ -63,13 +76,24 @@ export default function NotesPanel() {
           <span>Notes</span>
           <button onClick={newNote}>+</button>
         </div>
-        {notes.map(n => (
+        <input
+          className="note-search-input"
+          type="search"
+          placeholder="Search notes…"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          aria-label="Search notes"
+        />
+        {visibleNotes.map(n => (
           <div key={n.id}
             className={`note-item ${activeNote?.id === n.id ? 'active' : ''}`}
             onClick={() => selectNote(n)}>
             {n.title || 'Untitled'}
           </div>
         ))}
+        {visibleNotes.length === 0 && search.trim() !== '' && (
+          <div className="note-item-empty">No notes match “{search}”.</div>
+        )}
       </div>
 
       <div className="notes-editor">

--- a/frontend/src/components/Notes/NotesPanel.tsx
+++ b/frontend/src/components/Notes/NotesPanel.tsx
@@ -23,12 +23,12 @@ export default function NotesPanel() {
   // instead of the raw value (e.g. `"   foo  "` → `"foo"`).
   const trimmedSearch = search.trim();
 
-  // Client-side filter — see #6. Empty / whitespace-only input is
+  // Client-side filter, see #6. Empty / whitespace-only input is
   // treated as "no filter" so clearing the box restores the full list.
   // Memoised so unrelated re-renders (e.g. typing in the editor textarea)
   // don't pay the filter cost.
   // `title`/`content` come from the API as `Optional[str]` on the
-  // backend — coerce nulls to empty strings before lower-casing so a
+  // backend, coerce nulls to empty strings before lower-casing so a
   // missing field doesn't throw.
   const visibleNotes = useMemo(() => {
     const q = trimmedSearch.toLowerCase();


### PR DESCRIPTION
Closes #6.

## What

Adds a search input at the top of the Notes list that filters note
items in real time. Pure client-side, no API call.

## Behaviour

```ts
const visibleNotes = (() => {
  const q = search.trim().toLowerCase();
  if (q === '') return notes;
  return notes.filter(
    n => n.title.toLowerCase().includes(q) ||
         n.content.toLowerCase().includes(q),
  );
})();
```

- Empty / whitespace-only → no filter; full list shown.
- Case-insensitive substring match against `title` AND `content`.
- "No notes match …" placeholder when the filter matches nothing
  (so the panel doesn't go silently blank).

## A11y / UX

- `<input type="search">` (gives users the native clear button).
- `aria-label="Search notes"`.
- New `.note-search-input` CSS uses the project's existing
  `--color-primary` custom property for the focus border, matching
  the surrounding theme.

## Acceptance criteria

- [x] Search input visible at the top of the notes panel.
- [x] Filtering works client-side, no API call.
- [x] Case-insensitive matching against `title` and `content`.
- [x] Clearing the input restores the full note list.

## Verification

- `tsc --noEmit` reports no new errors in `NotesPanel.tsx`. (The two
  pre-existing errors in `Chat/ContextPreview.tsx` and `lib/api.ts`
  are unrelated to this PR.)